### PR TITLE
Fix dmenu result decoding

### DIFF
--- a/i3-hud-menu.py
+++ b/i3-hud-menu.py
@@ -65,7 +65,7 @@ def try_appmenu_interface(window_id):
 
   dmenu_cmd = subprocess.Popen(['dmenu', '-i', '-l', '10'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
   dmenu_cmd.stdin.write(dmenu_string.encode('utf-8'))
-  dmenu_result = dmenu_cmd.communicate()[0].decode('utf8')
+  dmenu_result = dmenu_cmd.communicate()[0].decode('utf-8').strip('\n')
   dmenu_cmd.stdin.close()
 
   # --- Use dmenu result
@@ -138,7 +138,7 @@ def try_gtk_interface(gtk_bus_name_cmd, gtk_object_path_cmd):
 
   dmenu_cmd = subprocess.Popen(['dmenu', '-i', '-l', '10'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
   dmenu_cmd.stdin.write(dmenu_string.encode('utf-8'))
-  dmenu_result = dmenu_cmd.communicate()[0].decode('utf8')
+  dmenu_result = dmenu_cmd.communicate()[0].decode('utf-8').strip('\n')
   dmenu_cmd.stdin.close()
 
   # --- Use dmenu result


### PR DESCRIPTION
Fixes two problems, each just enough to break dmenu result handling.
- Misprinting in encoding parameter string
- Strip newline
For now it just does nothing after selection.